### PR TITLE
Dependency update

### DIFF
--- a/lib/Fab/Fab.js
+++ b/lib/Fab/Fab.js
@@ -63,7 +63,11 @@ var Fab = function (_Component) {
       var buttonProps = isLink ? { component: _reactRouterDom.Link, to: onClick } : { onClick: onClick };
       return _react2.default.createElement(
         _Button2.default,
-        _extends({ variant: 'fab', color: 'secondary', className: classes.fab }, buttonProps),
+        _extends({
+          variant: 'fab',
+          color: 'secondary',
+          className: classes.fab
+        }, buttonProps),
         _react2.default.createElement(
           'i',
           { className: 'material-icons' },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "react-dev-utils": "^5.0.0",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
+    "redux-mock-store": "^1.5.1",
+    "redux-thunk": "^2.2.0",
     "style-loader": "0.20.1",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3011,12 +3011,6 @@ doctrine@^2.0.2:
   dependencies:
     esutils "^2.0.2"
 
-doctrine@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
-  dependencies:
-    esutils "^2.0.2"
-
 dom-converter@~0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
@@ -3492,9 +3486,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@4.17.0:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.17.0.tgz#dc24bb51ede48df629be7031c71d9dc0ee4f3ddf"
+eslint@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.15.0.tgz#89ab38c12713eec3d13afac14e4a89e75ef08145"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -3502,7 +3496,7 @@ eslint@4.17.0:
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
     debug "^3.1.0"
-    doctrine "^2.1.0"
+    doctrine "^2.0.2"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
     espree "^3.5.2"
@@ -7949,6 +7943,16 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-mock-store@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
 redux@^3.7.2:
   version "3.7.2"


### PR DESCRIPTION
Downgrading eslint 4.17 => 4.15 to be inline with latest react-scripts dependency. Also adding dependencies for passing all tests.